### PR TITLE
修复上一版本中 nvidia-smi 响应缓慢时仍会阻塞 GPU 检测、导致 OpenSpeedy 界面短暂无响应的问题

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1611,8 +1611,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c66fb449c6c2b488d43ca524b9fbbf92f910344551d38e1da4baeff8dfb1f1"
 dependencies = [
  "libloading 0.9.0",
- "objc2",
- "objc2-metal",
  "thiserror 2.0.18",
  "windows 0.62.2",
 ]
@@ -2319,17 +2317,6 @@ dependencies = [
  "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-metal"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
-dependencies = [
- "bitflags 2.13.0",
- "objc2",
- "objc2-foundation",
 ]
 
 [[package]]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -116,7 +116,12 @@ async fn bridge_get_speed() -> Option<f64> {
 
 #[tauri::command(async)]
 async fn get_system_stats() -> system_stats::SystemStats {
-    system_stats::get_system_stats()
+    // GPU APIs and stale display drivers can block for several seconds. Keep
+    // those synchronous probes off Tauri's event loop so the window stays
+    // responsive while the first probe is being resolved and cached.
+    tauri::async_runtime::spawn_blocking(system_stats::get_system_stats)
+        .await
+        .expect("system statistics worker panicked")
 }
 
 #[tauri::command(async)]

--- a/src-tauri/src/system_stats.rs
+++ b/src-tauri/src/system_stats.rs
@@ -1,9 +1,12 @@
+use std::io::Read;
 use std::os::windows::process::CommandExt;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Mutex, OnceLock,
 };
+use std::thread;
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 use windows::Win32::Foundation::FILETIME;
@@ -87,10 +90,22 @@ static CPU_PREV: Mutex<Option<CpuSnapshot>> = Mutex::new(None);
 // systems with a stale NVIDIA driver but no usable NVIDIA GPU. Keep the
 // fallback under our control so it is hidden and stop retrying after a failure.
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-static NVIDIA_SMI_UNAVAILABLE: AtomicBool = AtomicBool::new(false);
-static NVIDIA_SMI_QUERY_LOCK: Mutex<()> = Mutex::new(());
+const NVIDIA_SMI_TIMEOUT: Duration = Duration::from_secs(2);
+static GPU_STATS_UNAVAILABLE: AtomicBool = AtomicBool::new(false);
+static GPU_QUERY_LOCK: Mutex<()> = Mutex::new(());
 
 fn gpu_stats() -> Option<GpuStats> {
+    if GPU_STATS_UNAVAILABLE.load(Ordering::Acquire) {
+        return None;
+    }
+
+    // Serialize the complete native/fallback probe. Multiple frontend refreshes
+    // can overlap while a broken display driver is taking a long time to fail.
+    let _query_guard = GPU_QUERY_LOCK.lock().ok()?;
+    if GPU_STATS_UNAVAILABLE.load(Ordering::Acquire) {
+        return None;
+    }
+
     let native = hypomnesis::Snapshot::now(0).ok().and_then(|snap| {
         snap.gpu_device.map(|dev| GpuStats {
             name: dev.name.unwrap_or_default(),
@@ -99,37 +114,52 @@ fn gpu_stats() -> Option<GpuStats> {
         })
     });
 
-    native.or_else(nvidia_smi_gpu_stats)
+    if native.is_some() {
+        return native;
+    }
+
+    let fallback = nvidia_smi_gpu_stats();
+    if fallback.is_none() {
+        // A machine without a usable GPU will not recover during the process
+        // lifetime. Avoid repeatedly entering slow or broken driver code.
+        GPU_STATS_UNAVAILABLE.store(true, Ordering::Release);
+    }
+    fallback
 }
 
 fn nvidia_smi_gpu_stats() -> Option<GpuStats> {
-    if NVIDIA_SMI_UNAVAILABLE.load(Ordering::Acquire) {
-        return None;
-    }
-
-    let _query_guard = NVIDIA_SMI_QUERY_LOCK.lock().ok()?;
-    if NVIDIA_SMI_UNAVAILABLE.load(Ordering::Acquire) {
-        return None;
-    }
-
     let mut command = Command::new("nvidia-smi");
-    command.creation_flags(CREATE_NO_WINDOW);
-    let stats = command
+    command
+        .creation_flags(CREATE_NO_WINDOW)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
         .args([
             "--query-gpu=name,memory.used,memory.total",
             "--format=csv,noheader,nounits",
             "--id=0",
-        ])
-        .output()
-        .ok()
-        .filter(|output| output.status.success())
-        .and_then(|output| parse_nvidia_smi_output(&output.stdout));
+        ]);
 
-    if stats.is_none() {
-        NVIDIA_SMI_UNAVAILABLE.store(true, Ordering::Release);
+    let mut child = command.spawn().ok()?;
+    let deadline = Instant::now() + NVIDIA_SMI_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if !status.success() {
+                    return None;
+                }
+
+                let mut output = Vec::new();
+                child.stdout.take()?.read_to_end(&mut output).ok()?;
+                return parse_nvidia_smi_output(&output);
+            }
+            Ok(None) if Instant::now() < deadline => thread::sleep(Duration::from_millis(20)),
+            Ok(None) | Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
     }
-
-    stats
 }
 
 fn parse_nvidia_smi_output(output: &[u8]) -> Option<GpuStats> {


### PR DESCRIPTION
上一版本虽然解决了 nvidia-smi 弹出终端窗口的问题，但当损坏或残留的 NVIDIA 驱动响应缓慢时，GPU 检测仍可能长时间阻塞，导致 OpenSpeedy 界面暂时无响应；本次增加后台线程、2 秒超时、探测锁和失败缓存，避免界面卡顿及重复探测